### PR TITLE
Add backspace support for userText and userTextDisplay

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -98,6 +98,9 @@ var mainState = {
       mainState.checkForMatches(userText);
       userText = ''
       userTextDisplay.setText('');
+    } else if (e.keyCode === 8) {
+      userText = userText.slice(0,-1);
+      userTextDisplay.setText(userText);
     } else {
       userText += String.fromCharCode(e.keyCode);
       userTextDisplay.setText(userText);


### PR DESCRIPTION
Previously, there was no way for a user to delete typos.  If a typo occurred, the user would need to submit the misspelled word and retype it from the beginning.  

This change updates the keyUp handler to allow the user to delete mistakenly entered text using the backspace key, resulting in a smoother user experience. 
